### PR TITLE
Ignore all files matching /config/*.secret.exs pattern.

### DIFF
--- a/installer/templates/assets/bare/gitignore
+++ b/installer/templates/assets/bare/gitignore
@@ -7,10 +7,10 @@
 # Generated on crash by the VM
 erl_crash.dump
 
-# The config/prod.secret.exs file by default contains sensitive
-# data and you should not commit it into version control.
+# Files matching config/*.secret.exs pattern contain sensitive
+# data and you should not commit them into version control.
 #
 # Alternatively, you may comment the line below and commit the
-# secrets file as long as you replace its contents by environment
+# secrets files as long as you replace their contents by environment
 # variables.
-/config/prod.secret.exs
+/config/*.secret.exs


### PR DESCRIPTION
Hey Guys,

**TL;DR:** In this PR I propose to ignore all secret files in the config folder.

I read through the “Programming Phoenix” book the other day. In this book I came across a chapter where I had to create dev.secret.exs in the config folder. 

In order to protect it I had to put it into .gitignore. So I thought we should ignore all secret files matching the pattern by default.